### PR TITLE
Changing devtool to cheap-module-source-map for better Chrome compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server -d --history-api-fallback --hot --inline --progress --colors --port 3000 --open",
+    "start": "webpack-dev-server --debug --devtool cheap-module-source-map --output-pathinfo --history-api-fallback --hot --inline --progress --colors --port 3000 --open",
     "build": "webpack -p --progress --colors"
   },
   "license": "MIT",


### PR DESCRIPTION
It seems that Chrome has an issue with source maps when the devtool setting is set to the default `sourcemap` value, which is part of what the `-d` option on webpack-dev-server does. There is a thread about this issue here https://github.com/webpack/webpack/issues/2145 that suggests that the most compatible setting for use with Chrome is `cheap-module-source-map`. Quick testing shows that this setting makes breakpoints work reliably in the source maps, and it allows Chrome to reliably map from the js bundle to the corresponding source file.

Many projects have separate files for `webpack.config.js` for dev and for prod, and also a separate file for the dev server config. That helps avoid putting in so many options in `package.json` scripts, but it adds complexity that may not really belong in this boilerplate. Let me know if you would prefer that approach, and I can make a PR in that direction. Otherwise this is the one line fix :)