### PR TITLE
Added 'browser' to mainFields configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
     extensions: ['.js', '.ts', '.tsx'],
     // Fix webpack's default behavior to not load packages with jsnext:main module
     // https://github.com/Microsoft/TypeScript/issues/11677
-    mainFields: ['main']
+    mainFields: ['browser', 'main']
   },
   module: {
     loaders: [


### PR DESCRIPTION
The boilerplate's webpack,config.js is not picking up the browser flavor of libraries because it explicitly stated in the mainFields configuration:
mainFields: ["main"]
Since we are targeting browser, it should be changed to:
mainFields: ["browser", "main"]

See https://github.com/ethereum/web3.js/issues/1121 for more details.