### PR TITLE
Use strictNullChecks

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,10 +11,12 @@ export namespace Header {
   }
 }
 
+const emptyProps: Header.Props = { addTodo: (_) => null }
+
 export class Header extends React.Component<Header.Props, Header.State> {
 
   constructor(props?: Header.Props, context?: any) {
-    super(props, context);
+    super(props || emptyProps, context || {});
     this.handleSave = this.handleSave.bind(this);
   }
 

--- a/src/components/MainSection/index.tsx
+++ b/src/components/MainSection/index.tsx
@@ -23,17 +23,19 @@ export namespace MainSection {
   }
 }
 
+const emptyProps: MainSection.Props = { todos: [], actions: TodoActions }
+
 export class MainSection extends React.Component<MainSection.Props, MainSection.State> {
 
   constructor(props?: MainSection.Props, context?: any) {
-    super(props, context);
+    super(props || emptyProps, context || {});
     this.state = { filter: SHOW_ALL };
     this.handleClearCompleted = this.handleClearCompleted.bind(this);
     this.handleShow = this.handleShow.bind(this);
   }
 
   handleClearCompleted() {
-    const atLeastOneCompleted = this.props.todos.some(todo => todo.completed);
+    const atLeastOneCompleted = this.props.todos.some(todo => todo.completed || false);
     if (atLeastOneCompleted) {
       this.props.actions.clearCompleted();
     }

--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -17,10 +17,17 @@ export namespace TodoItem {
   }
 }
 
+const emptyProps: TodoItem.Props = {
+  todo: {},
+  editTodo: (_) => null,
+  deleteTodo: (_) => null,
+  completeTodo: (_) => null
+}
+
 export class TodoItem extends React.Component<TodoItem.Props, TodoItem.State> {
 
   constructor(props?: TodoItem.Props, context?: any) {
-    super(props, context);
+    super(props || emptyProps, context || {});
     this.state = {
       editing: false
     };
@@ -49,7 +56,7 @@ export class TodoItem extends React.Component<TodoItem.Props, TodoItem.State> {
       element = (
         <TodoTextInput text={todo.text}
           editing={this.state.editing}
-          onSave={(text) => this.handleSave(todo.id, text)} />
+          onSave={(text) => { if (todo.id) this.handleSave(todo.id, text) }} />
       );
     } else {
       element = (
@@ -57,13 +64,13 @@ export class TodoItem extends React.Component<TodoItem.Props, TodoItem.State> {
           <input className={style.toggle}
             type="checkbox"
             checked={todo.completed}
-            onChange={() => completeTodo(todo.id)} />
+            onChange={() => { if (todo.id) completeTodo(todo.id) }} />
 
           <label onDoubleClick={this.handleDoubleClick}>
             {todo.text}
           </label>
 
-          <button className={style.destroy} onClick={() => deleteTodo(todo.id)} />
+          <button className={style.destroy} onClick={() => { if (todo.id) deleteTodo(todo.id) }} />
         </div>
       );
     }

--- a/src/components/TodoTextInput/index.tsx
+++ b/src/components/TodoTextInput/index.tsx
@@ -16,10 +16,14 @@ export namespace TodoTextInput {
   }
 }
 
+const emptyProps: TodoTextInput.Props = {
+  onSave: (_) => null,
+}
+
 export class TodoTextInput extends React.Component<TodoTextInput.Props, TodoTextInput.State> {
 
   constructor(props?: TodoTextInput.Props, context?: any) {
-    super(props, context);
+    super(props || emptyProps, context || {});
     this.state = {
       text: this.props.text || ''
     };

--- a/src/reducers/todos.ts
+++ b/src/reducers/todos.ts
@@ -10,7 +10,7 @@ const initialState: TodoStoreState = [{
 export default handleActions<TodoStoreState, TodoItemData>({
   [Actions.ADD_TODO]: (state, action) => {
     return [{
-      id: state.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1,
+      id: state.reduce((maxId, todo) => Math.max(todo.id || 0, maxId), -1) + 1,
       completed: false,
       ...action.payload,
     }, ...state];
@@ -22,9 +22,13 @@ export default handleActions<TodoStoreState, TodoItemData>({
 
   [Actions.EDIT_TODO]: (state, action) => {
     return state.map(todo => {
-      return todo.id === action.payload.id
-        ? { ...todo, text: action.payload.text }
-        : todo;
+      if (!todo || !action || !action.payload) {
+        return todo;
+      } else {
+        return (todo.id || 0) === action.payload.id
+          ? { ...todo, text: action.payload.text }
+          : todo;
+      }
     });
   },
 
@@ -37,7 +41,7 @@ export default handleActions<TodoStoreState, TodoItemData>({
   },
 
   [Actions.COMPLETE_ALL]: (state, action) => {
-    const areAllMarked = state.every(todo => todo.completed);
+    const areAllMarked = state.every(todo => todo.completed || false);
     return state.map(todo => {
       return {
         ...todo,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noImplicitAny": false,
     "noImplicitReturns": false,
     "removeComments": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "outDir": "build",
     "lib": [
       "es6",


### PR DESCRIPTION
This PR switches strictNullChecks on. But the implementation is far from ideal.

I simply added "fixed" the compile errors, without going through the code to see if types could be defined more specific.  Like:

```ts
declare interface TodoItemData {
  id?: TodoItemId;
  text?: string;
  completed?: boolean;
}
```

This could drop all the `?`s (no string is simply `""`, and the others should never be empty, right?).

