### PR TITLE
Fix Typescript compilation issue #45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8076,9 +8076,9 @@
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
-      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0=",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
+      "integrity": "sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg==",
       "dev": true
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "postcss-url": "^7.3.2",
     "prettier": "^1.13.5",
     "react-hot-loader": "^4.3.1",
-    "redux-devtools-extension": "^2.13.2",
+    "redux-devtools-extension": "^2.13.5",
     "style-loader": "^0.21.0",
     "ts-loader": "^4.4.1",
     "typescript": "^2.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "removeComments": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "keyofStringsOnly": true,
     "strict": true,
     "outDir": "build",
     "lib": ["es6", "es7", "dom"],


### PR DESCRIPTION
- Disable new keyOf behavior in Typescript 2.9
- https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-29
- Upgrade to more recent redux-devtools-extension to fix
  missing reference to GenericStoreEnhancer