### PR TITLE
Update webpack configuration for production

### DIFF
--- a/src/app/middleware/logger.ts
+++ b/src/app/middleware/logger.ts
@@ -1,6 +1,8 @@
 import { Middleware } from 'redux';
 
 export const logger: Middleware = (store) => (next) => (action) => {
-  console.log(action);
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(action);
+  }
   return next(action);
 };

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>
     <title>Frontend Boilerplate with React and TypeScript</title>
   </head>
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,8 +78,8 @@ module.exports = {
       },
       // static assets
       { test: /\.html$/, use: 'html-loader' },
-      { test: /\.(png|svg)$/, use: 'url-loader?limit=10000' },
-      { test: /\.(jpg|gif|eot|ttf|woff|woff2)$/, use: 'file-loader' }
+      { test: /\.(a?png|svg)$/, use: 'url-loader?limit=10000' },
+      { test: /\.(jpe?g|gif|bmp|mp3|mp4|ogg|wav|eot|ttf|woff|woff2)$/, use: 'file-loader' }
     ]
   },
   optimization: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
       {
         test: /\.tsx?$/,
         use: [
-          isProduction && {
+          !isProduction && {
             loader: 'babel-loader',
             options: { plugins: ['react-hot-loader/babel'] }
           },
@@ -120,8 +120,11 @@ module.exports = {
     historyApiFallback: {
       disableDotRule: true
     },
-    stats: 'minimal'
+    stats: 'minimal',
+    clientLogLevel: 'warning'
   },
+  // https://webpack.js.org/configuration/devtool/
+  devtool: isProduction ? 'hidden-source-map' : 'cheap-module-eval-source-map',
   node: {
     // workaround for webpack-dev-server issue
     // https://github.com/webpack/webpack-dev-server/issues/60#issuecomment-103411179


### PR DESCRIPTION
- fix react-hot-loader configuration
- set devServer.clientLogLevel as warning
- set devtool for production as hidden-source-map
- add polyfill.io script to index.html
- add more static file extension to the webpack resolution
- suppress logger middleware output in production build